### PR TITLE
Fix heredoc handling with pipelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ SRCS = src/main/main.c \
 	   src/exec/execute.c \
 	   src/exec/find_path.c \
 	   src/exec/handle_heredoc.c \
+           src/exec/collect_heredocs.c \
 	   src/exec/validate_command.c \
 	   src/exec/find_and_execute.c \
 	   src/expander/expander.c \

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -60,6 +60,7 @@ typedef struct s_redir
 	char			*file;
 	char			*original_file;
 	int				expand_content;
+	int	here_fd;
 	struct s_redir	*next;
 }					t_redir;
 
@@ -135,9 +136,11 @@ int		open_file(char *filename, int flags, int mode);
 int		dup_fd(int old_fd, int new_fd, char *type);
 int		setup_redir(t_shell *shell);
 int		handle_heredoc_redir(t_shell *shell, int is_last_heredoc);
+int		collect_heredoc_fd(t_shell *shell, t_redir *redir);
 int		execute_pipe(t_shell *shell);
 int		apply_redirection(t_redir *redir);
 int		init_heredoc(t_shell *shell);
+int		collect_all_heredocs(t_shell *shell);
 int		validate_command(t_shell *shell, char **env_array);
 char	*find_path(char *cmd, char *envp[]);
 void	exec_external_direct(t_shell *shell, char **env_array);

--- a/src/exec/collect_heredocs.c
+++ b/src/exec/collect_heredocs.c
@@ -1,0 +1,26 @@
+#include "minishell.h"
+
+int collect_all_heredocs(t_shell *shell)
+{
+    t_command *cmd;
+    t_redir   *r;
+    int       ret;
+
+    cmd = shell->command;
+    while (cmd)
+    {
+        r = cmd->redir;
+        while (r)
+        {
+            if (r->type == REDIR_HEREDOC)
+            {
+                ret = collect_heredoc_fd(shell, r);
+                if (ret != 0)
+                    return ret;
+            }
+            r = r->next;
+        }
+        cmd = cmd->next;
+    }
+    return 0;
+}

--- a/src/exec/handle_heredoc.c
+++ b/src/exec/handle_heredoc.c
@@ -149,6 +149,19 @@ int	handle_heredoc_redir(t_shell *shell, int is_last_heredoc)
 			return (ERROR);
 		}
 	}
-	close(pipe_fd[0]);
-	return (0);
+       close(pipe_fd[0]);
+       return (0);
+}
+
+int     collect_heredoc_fd(t_shell *shell, t_redir *redir)
+{
+       int     pipe_fd[2];
+       int     result;
+
+       shell->redir = redir;
+       result = setup_and_collect_heredoc(shell, 1, pipe_fd);
+       if (result != 0)
+               return (result);
+       redir->here_fd = pipe_fd[0];
+       return (0);
 }

--- a/src/exec/setup_redir.c
+++ b/src/exec/setup_redir.c
@@ -55,6 +55,17 @@ static int	process_heredoc(t_shell *shell, t_redir *redir,
 	int	ret;
 
 	shell->redir = redir;
+    if (redir->here_fd != -1) {
+        if (redir == last_heredoc) {
+            if (dup_fd(redir->here_fd, STDIN_FILENO, "heredoc") == ERROR) {
+                close(redir->here_fd);
+                return (ERROR);
+            }
+        }
+        close(redir->here_fd);
+        redir->here_fd = -1;
+        return (0);
+    }
 	if (redir == last_heredoc)
 	{
 		ret = handle_heredoc_redir(shell, 1);

--- a/src/main/process_line.c
+++ b/src/main/process_line.c
@@ -89,10 +89,12 @@ int	process_line(char *raw_line_ptr, t_shell *shell)
 		cleanup_iteration_resources(raw_line_ptr, shell);
 		return (0);
 	}
-	if (handle_parsing(shell))
-		return (handle_parse_error(raw_line_ptr, shell));
-	else if (shell->command && !shell->heredoc_eof)
-		run_command(shell);
+       if (handle_parsing(shell))
+               return (handle_parse_error(raw_line_ptr, shell));
+       if (collect_all_heredocs(shell) == ERROR)
+               return (handle_parse_error(raw_line_ptr, shell));
+       else if (shell->command && !shell->heredoc_eof)
+               run_command(shell);
 	if (*shell->line)
 		add_history(shell->line);
 	cleanup_iteration_resources(raw_line_ptr, shell);

--- a/src/parser/parse_redirections.c
+++ b/src/parser/parse_redirections.c
@@ -45,8 +45,9 @@ static t_redir	*new_redir_node(t_token_type tt, char *file)
 	r = ft_calloc(1, sizeof(t_redir));
 	if (!r)
 		return (print_error_null(NULL, NULL, strerror(errno)));
-	r->type = get_redir_type(tt);
-	r->original_file = ft_strdup(file);
+       r->type = get_redir_type(tt);
+       r->here_fd = -1;
+       r->original_file = ft_strdup(file);
 	if (!r->original_file)
 	{
 		free(r);

--- a/src/utils/free.c
+++ b/src/utils/free.c
@@ -63,12 +63,14 @@ void	free_redirections(t_redir *r)
 			free(r->file);
 			r->file = NULL;
 		}
-		if (r->original_file)
-		{
-			free(r->original_file);
-			r->original_file = NULL;
-		}
-		free(r);
-		r = next;
-	}
+               if (r->original_file)
+               {
+                       free(r->original_file);
+                       r->original_file = NULL;
+               }
+               if (r->here_fd != -1)
+                       close(r->here_fd);
+               free(r);
+               r = next;
+       }
 }


### PR DESCRIPTION
## Summary
- store heredoc contents in pipes ahead of execution
- keep fd for each heredoc in `t_redir`
- close heredoc fds during cleanup
- gather all heredocs before running commands
- apply saved heredoc fds when setting up redirections

## Testing
- `make`
- `printf 'cat << a << b | echo deneme\nselam\na\nb\n' | ./minishell`

------
https://chatgpt.com/codex/tasks/task_e_6870cd6c373c8332bf7aaacb614f25fc